### PR TITLE
Implement DrawPath and FillPath methods for drawing and filling GraphicsPath objects.

### DIFF
--- a/SvgGdiTest/SvgGdiTestForm.Designer.cs
+++ b/SvgGdiTest/SvgGdiTestForm.Designer.cs
@@ -99,7 +99,8 @@ namespace SvgGdiTest
             "Images",
             "Text",
             "Rect-aligned Text",
-            "Fills"});
+            "Fills",
+            "Path"});
             this.cbWhat.Location = new System.Drawing.Point(816, 12);
             this.cbWhat.MaxDropDownItems = 30;
             this.cbWhat.Name = "cbWhat";

--- a/SvgGdiTest/SvgGdiTestForm.Designer.cs
+++ b/SvgGdiTest/SvgGdiTestForm.Designer.cs
@@ -100,7 +100,8 @@ namespace SvgGdiTest
             "Text",
             "Rect-aligned Text",
             "Fills",
-            "Path"});
+            "Path",
+            "Path 2 (Slow)"});
             this.cbWhat.Location = new System.Drawing.Point(816, 12);
             this.cbWhat.MaxDropDownItems = 30;
             this.cbWhat.Name = "cbWhat";

--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -480,7 +480,7 @@ namespace SvgGdiTest
                 //ig.DrawImageUnscaled(bmp, 270, 450, 20, 20);
             }
             else if (s == "Path")
-            {                
+            {
                 /* The following example GraphicsPath code comes from the MSDN docs on the GraphicsPathIterator class
                  * https://msdn.microsoft.com/en-us/library/79k451ts.aspx
                  * 
@@ -489,7 +489,7 @@ namespace SvgGdiTest
                 GraphicsPath myPath = new GraphicsPath();
 
                 // Set up primitives to add to myPath.
-                Point[] myPoints = {new Point(20, 20), new Point(120, 120), new Point(20, 120),new Point(20, 20) };
+                Point[] myPoints = { new Point(20, 20), new Point(120, 120), new Point(20, 120), new Point(20, 20) };
                 Rectangle myRect = new Rectangle(120, 120, 100, 100);
 
                 // Add 3 lines, a rectangle, an ellipse, and 2 markers.
@@ -498,11 +498,12 @@ namespace SvgGdiTest
                 myPath.AddRectangle(myRect);
                 myPath.SetMarkers();
                 myPath.AddEllipse(220, 220, 100, 100);
+                myPath.AddLine(new PointF(40, 20), new PointF(80, 120));
                 ig.DrawPath(new Pen(Color.Black), myPath);
                 LinearGradientBrush gbr2 = new LinearGradientBrush(new Point(0, 0), new Point(10, 20), Color.WhiteSmoke, Color.CornflowerBlue);
                 gbr2.WrapMode = WrapMode.TileFlipXY;
                 SolidBrush redBrush = new SolidBrush(Color.Red);
-                ig.FillPath(redBrush, myPath);
+                ig.FillPath(gbr2, myPath);
             }
             else
             {

--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -499,6 +499,10 @@ namespace SvgGdiTest
                 myPath.SetMarkers();
                 myPath.AddEllipse(220, 220, 100, 100);
                 ig.DrawPath(new Pen(Color.Black), myPath);
+                LinearGradientBrush gbr2 = new LinearGradientBrush(new Point(0, 0), new Point(10, 20), Color.WhiteSmoke, Color.CornflowerBlue);
+                gbr2.WrapMode = WrapMode.TileFlipXY;
+                SolidBrush redBrush = new SolidBrush(Color.Red);
+                ig.FillPath(redBrush, myPath);
             }
             else
             {

--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -498,12 +498,28 @@ namespace SvgGdiTest
                 myPath.AddRectangle(myRect);
                 myPath.SetMarkers();
                 myPath.AddEllipse(220, 220, 100, 100);
-                myPath.AddLine(new PointF(40, 20), new PointF(80, 120));
                 ig.DrawPath(new Pen(Color.Black), myPath);
                 LinearGradientBrush gbr2 = new LinearGradientBrush(new Point(0, 0), new Point(10, 20), Color.WhiteSmoke, Color.CornflowerBlue);
                 gbr2.WrapMode = WrapMode.TileFlipXY;
-                SolidBrush redBrush = new SolidBrush(Color.Red);
                 ig.FillPath(gbr2, myPath);
+            }
+            else if (s == "Path 2 (Slow)")
+            {
+                /* The following example GraphicsPath code comes from the MSDN docs on the GraphicsPathIterator class
+                 * https://msdn.microsoft.com/en-us/library/79k451ts.aspx
+                 * 
+                 */
+                // Create a graphics path.
+                GraphicsPath myPath = new GraphicsPath();
+                myPath.AddString("String path", FontFamily.GenericMonospace, (int)FontStyle.Regular, 24,
+                    new PointF(0, 0), StringFormat.GenericTypographic);
+                ig.DrawPath(new Pen(Color.Green), myPath);
+                GraphicsPath myPath2 = new GraphicsPath();
+                myPath2.AddString("String path filled", FontFamily.GenericMonospace, (int)FontStyle.Regular, 24,
+                    new PointF(100, 50), StringFormat.GenericTypographic);
+                SolidBrush redBrush = new SolidBrush(Color.Red);
+                ig.DrawPath(new Pen(Color.Black), myPath2);
+                ig.FillPath(redBrush, myPath2);
             }
             else
             {

--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -479,6 +479,27 @@ namespace SvgGdiTest
                 ig.EndContainer(cnt);
                 //ig.DrawImageUnscaled(bmp, 270, 450, 20, 20);
             }
+            else if (s == "Path")
+            {                
+                /* The following example GraphicsPath code comes from the MSDN docs on the GraphicsPathIterator class
+                 * https://msdn.microsoft.com/en-us/library/79k451ts.aspx
+                 * 
+                 */
+                // Create a graphics path.
+                GraphicsPath myPath = new GraphicsPath();
+
+                // Set up primitives to add to myPath.
+                Point[] myPoints = {new Point(20, 20), new Point(120, 120), new Point(20, 120),new Point(20, 20) };
+                Rectangle myRect = new Rectangle(120, 120, 100, 100);
+
+                // Add 3 lines, a rectangle, an ellipse, and 2 markers.
+                myPath.AddLines(myPoints);
+                myPath.SetMarkers();
+                myPath.AddRectangle(myRect);
+                myPath.SetMarkers();
+                myPath.AddEllipse(220, 220, 100, 100);
+                ig.DrawPath(new Pen(Color.Black), myPath);
+            }
             else
             {
                 throw new NotImplementedException();

--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -505,21 +505,26 @@ namespace SvgGdiTest
             }
             else if (s == "Path 2 (Slow)")
             {
-                /* The following example GraphicsPath code comes from the MSDN docs on the GraphicsPathIterator class
-                 * https://msdn.microsoft.com/en-us/library/79k451ts.aspx
-                 * 
-                 */
-                // Create a graphics path.
-                GraphicsPath myPath = new GraphicsPath();
-                myPath.AddString("String path", FontFamily.GenericMonospace, (int)FontStyle.Regular, 24,
-                    new PointF(0, 0), StringFormat.GenericTypographic);
-                ig.DrawPath(new Pen(Color.Green), myPath);
-                GraphicsPath myPath2 = new GraphicsPath();
-                myPath2.AddString("String path filled", FontFamily.GenericMonospace, (int)FontStyle.Regular, 24,
-                    new PointF(100, 50), StringFormat.GenericTypographic);
-                SolidBrush redBrush = new SolidBrush(Color.Red);
-                ig.DrawPath(new Pen(Color.Black), myPath2);
-                ig.FillPath(redBrush, myPath2);
+                SolidBrush mySolidBrush = new SolidBrush(Color.Aqua);
+                GraphicsPath myGraphicsPath = new GraphicsPath();
+
+                Point[] myPointArray = {
+                    new Point(15, 20),
+                    new Point(20, 40),      
+                    new Point(50, 30)};
+
+                FontFamily myFontFamily = new FontFamily("Times New Roman");
+                PointF myPointF = new PointF(50, 20);
+                StringFormat myStringFormat = new StringFormat();
+
+                myGraphicsPath.AddArc(0, 0, 30, 20, -90, 180);
+                myGraphicsPath.AddCurve(myPointArray);
+                myGraphicsPath.AddString("a string in a path filled", myFontFamily,
+                   0, 24, myPointF, myStringFormat);
+                myGraphicsPath.AddPie(230, 10, 40, 40, 40, 110);
+
+                ig.FillPath(mySolidBrush, myGraphicsPath);
+                ig.DrawPath(new Pen(Color.Green), myGraphicsPath);
             }
             else
             {

--- a/SvgNet/SVGGraphics.cs
+++ b/SvgNet/SVGGraphics.cs
@@ -1969,6 +1969,11 @@ namespace SvgNet.SvgGdi
         /// <summary>
         /// Implemented
         /// </summary>
+        /// <remarks>
+        /// Mainly based on the libgdi+ implementation: https://github.com/mono/libgdiplus/blob/master/src/graphics-cairo.c
+        /// and this SO question reply: https://stackoverflow.com/questions/1790862/how-to-determine-endpoints-of-arcs-in-graphicspath-pathpoints-and-pathtypes-arra
+        /// from SiiliconMind.
+        /// </remarks>
         public void DrawPath(Pen pen, GraphicsPath path)
         {
             //Save the original pen dash style in case we need to change it
@@ -1994,12 +1999,13 @@ namespace SvgNet.SvgGdi
                 PointF[] bezierCurvePoints = new PointF[4];
                 for (int i = 0; i < subpath.PathPoints.Length; i++)
                 {
-                    /* Each subpath point has a corresponding type which can be:
+                    /* Each subpath point has a corresponding path point type which can be:
                      *The point starts the subpath
                      *The point is a line point
                      *The point is Bezier curve point
+                     * Another point type like dash-mode
                      */
-                    switch ((PathPointType)subpath.PathTypes[i] & PathPointType.PathTypeMask)
+                    switch ((PathPointType)subpath.PathTypes[i] & PathPointType.PathTypeMask) //Mask off non path-type types
                     {
                         case PathPointType.Start:
                             start = subpath.PathPoints[i];
@@ -2023,6 +2029,7 @@ namespace SvgNet.SvgGdi
                             }
                             continue;
                         default:
+                            
                             switch ((PathPointType)subpath.PathTypes[i])
                             {
                                 case PathPointType.DashMode:

--- a/SvgNet/SvgNet.csproj
+++ b/SvgNet/SvgNet.csproj
@@ -170,7 +170,13 @@
   <PropertyGroup>
     <PreBuildEvent />
     <PostBuildEvent>cd $(ProjectDir)
-nuget pack SvgNet.csproj</PostBuildEvent>
+nuget pack SvgNet.csproj
+IF NOT %25ERRORLEVEL%25==0 (
+  echo Did not build NuGet package.
+  exit /b 0
+)
+
+</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/SvgNet/svgnetdoc.xml
+++ b/SvgNet/svgnetdoc.xml
@@ -504,6 +504,11 @@
             <summary>
             Implemented
             </summary>
+            <remarks>
+            Mainly based on the libgdi+ implementation: https://github.com/mono/libgdiplus/blob/master/src/graphics-cairo.c
+            and this SO question reply: https://stackoverflow.com/questions/1790862/how-to-determine-endpoints-of-arcs-in-graphicspath-pathpoints-and-pathtypes-arra
+            from SiiliconMind.
+            </remarks>
         </member>
         <member name="M:SvgNet.SvgGdi.SvgGraphics.DrawPie(System.Drawing.Pen,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
             <summary>

--- a/SvgNet/svgnetdoc.xml
+++ b/SvgNet/svgnetdoc.xml
@@ -502,7 +502,7 @@
         </member>
         <member name="M:SvgNet.SvgGdi.SvgGraphics.DrawPath(System.Drawing.Pen,System.Drawing.Drawing2D.GraphicsPath)">
             <summary>
-            Not implemented because GDI+ regions/paths are not emulated.
+            Implemented.
             </summary>
         </member>
         <member name="M:SvgNet.SvgGdi.SvgGraphics.DrawPie(System.Drawing.Pen,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">

--- a/SvgNet/svgnetdoc.xml
+++ b/SvgNet/svgnetdoc.xml
@@ -502,7 +502,7 @@
         </member>
         <member name="M:SvgNet.SvgGdi.SvgGraphics.DrawPath(System.Drawing.Pen,System.Drawing.Drawing2D.GraphicsPath)">
             <summary>
-            Implemented.
+            Implemented
             </summary>
         </member>
         <member name="M:SvgNet.SvgGdi.SvgGraphics.DrawPie(System.Drawing.Pen,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">

--- a/SvgNet/svgnetdoc.xml
+++ b/SvgNet/svgnetdoc.xml
@@ -664,7 +664,7 @@
         </member>
         <member name="M:SvgNet.SvgGdi.SvgGraphics.FillPath(System.Drawing.Brush,System.Drawing.Drawing2D.GraphicsPath)">
             <summary>
-            Not implemented, because GDI+ regions/paths are not emulated.
+            Implemented
             </summary>
         </member>
         <member name="M:SvgNet.SvgGdi.SvgGraphics.FillPie(System.Drawing.Brush,System.Drawing.Rectangle,System.Single,System.Single)">


### PR DESCRIPTION

![svgnet1](https://user-images.githubusercontent.com/11426372/29795583-d9ff2c56-8c1a-11e7-87c8-9a97528dc3a5.png)
![svgnet2](https://user-images.githubusercontent.com/11426372/29795584-da5155b2-8c1a-11e7-9347-8705c5b8ecc2.png)



This is an initial implementation of the GDI DrawPath and FillPath functions for working with GraphicsPath objects. I believe it is mostly accurate as it is able to draw and fill complex paths like text strings albeit with small inaccuracies. Drawing strings using paths is probably not a typical use of GDI GraphicsPath objects though so this may not matter much. Other simpler paths appear to be drawn accurately. Maybe the person who opened  #8 can test it out.