### PR TITLE
Updated path drawing to use SvgPathElement

### DIFF
--- a/SvgGdiTest/SvgGdiTestForm.Designer.cs
+++ b/SvgGdiTest/SvgGdiTestForm.Designer.cs
@@ -101,6 +101,7 @@ namespace SvgGdiTest
             "Rect-aligned Text",
             "Fills",
             "Path",
+            "Path Polygon",
             "Path 2 (Slow)"});
             this.cbWhat.Location = new System.Drawing.Point(816, 12);
             this.cbWhat.MaxDropDownItems = 30;

--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -512,6 +512,21 @@ namespace SvgGdiTest
                 myPath2.AddBezier(130, 160, 170, 160, 150, 130, 200, 110);
                 ig.DrawPath(new Pen(Color.Blue, 1.7f), myPath2);
             }
+            else if (s == "Path Polygon")
+            {
+                GraphicsPath myPath = new GraphicsPath();
+                ig.SmoothingMode = SmoothingMode.AntiAlias;
+
+                // Set up primitives to add to myPath.
+                Point[] myPoints = { new Point(45, 133), new Point(117, 125), new Point(150, 60), new Point(183, 125), new Point(252, 133),
+                                     new Point(200, 186), new Point(211, 258), new Point(150, 223), new Point(83, 258), new Point(97, 186)};
+                Rectangle myRect = new Rectangle(120, 120, 100, 100);
+
+                // Add polygon closed path.
+                myPath.AddLines(myPoints);
+                myPath.CloseFigure();
+                ig.DrawPath(new Pen(Color.Black, 5f), myPath);
+            }
             else if (s == "Path 2 (Slow)")
             {
                 SolidBrush mySolidBrush = new SolidBrush(Color.Aqua);

--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -517,14 +517,19 @@ namespace SvgGdiTest
                 GraphicsPath myPath = new GraphicsPath();
                 ig.SmoothingMode = SmoothingMode.AntiAlias;
 
-                // Set up primitives to add to myPath.
-                Point[] myPoints = { new Point(45, 133), new Point(117, 125), new Point(150, 60), new Point(183, 125), new Point(252, 133),
-                                     new Point(200, 186), new Point(211, 258), new Point(150, 223), new Point(83, 258), new Point(97, 186)};
-                Rectangle myRect = new Rectangle(120, 120, 100, 100);
-
                 // Add polygon closed path.
-                myPath.AddLines(myPoints);
+                Point[] starPoints = { new Point(45, 133), new Point(117, 125), new Point(150, 60), new Point(183, 125), new Point(252, 133),
+                                       new Point(200, 186), new Point(211, 258), new Point(150, 223), new Point(83, 258), new Point(97, 186)};
+                myPath.AddLines(starPoints);
                 myPath.CloseFigure();
+
+                // Add bezier-line combination path
+                Point[] pathPoints1 = { new Point(24, 60), new Point(60, -16), new Point(48, 96), new Point(84, 20) };
+                Point[] pathPoints2 = { new Point(84, 20), new Point(104, 60) };
+                myPath.AddBeziers(pathPoints1);
+                myPath.AddLines(pathPoints2);
+
+                ig.FillPath(new SolidBrush(Color.Aqua), myPath);
                 ig.DrawPath(new Pen(Color.Black, 5f), myPath);
             }
             else if (s == "Path 2 (Slow)")

--- a/SvgNet/AssemblyInfo.cs
+++ b/SvgNet/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCulture("")]		
 
 [assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.5")]
-[assembly: AssemblyInformationalVersion("1.0.5")]
+[assembly: AssemblyFileVersion("1.0.6")]
+[assembly: AssemblyInformationalVersion("1.0.6")]
 
 [assembly: AssemblyDelaySign(false)]
 [assembly: AssemblyKeyFile("")]


### PR DESCRIPTION
This fixes #8. The solution was to use the more general SVG `path` element, since it already supports lines and bezier curves, both open-ended or closed. It also turns out you can use the exact same code for both `FillPath` and `DrawPath`, since the only difference between the two is in the `stroke` and `fill` definitions.

I have included tests for closed polygon figures and bezier-line combinations that were breaking under the previous implementation.

It is possible the SVG output could be optimized further by caching the data from the last emitted paths. This would make it possible to set both `fill` and `stroke` style at the same time if you would call `FillPath` and `DrawPath` successively, but at least for now it seems to work correctly, both on the previous and new tests.