### PR TITLE
Fixed SVG export for filled interior of a closed path

### DIFF
--- a/SvgGdiTest/SvgGdiTestForm.cs
+++ b/SvgGdiTest/SvgGdiTestForm.cs
@@ -514,6 +514,11 @@ namespace SvgGdiTest
                 myPath2.AddEllipse(120, 120, 120, 140);
                 myPath2.AddBezier(130, 160, 170, 160, 150, 130, 200, 110);
                 ig.DrawPath(new Pen(Color.Blue, 1.7f), myPath2);
+
+                GraphicsPath myPath3 = new GraphicsPath();
+                myPath3.AddEllipse(120, 50, 50, 50);
+                myPath3.AddEllipse(135, 65, 30, 30);
+                ig.FillPath(Brushes.Blue, myPath3);
             }
             else if (s == "Path Polygon")
             {

--- a/SvgNet/SVGGraphics.cs
+++ b/SvgNet/SVGGraphics.cs
@@ -2288,6 +2288,14 @@ namespace SvgNet.SvgGdi
             SvgPathElement pathElement = new SvgPathElement();
             SvgPath svgPath = HandleGraphicsPath(path);
             pathElement.Style = HandleBrush(brush);
+            if (path.FillMode == FillMode.Alternate)
+            {
+                pathElement.Style.Set("fill-rule", "evenodd");
+            }
+            else
+            {
+                pathElement.Style.Set("fill-rule", "nonzero");
+            }
             pathElement.D = svgPath;
             if (!_transforms.Result.IsIdentity)
                 pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());

--- a/SvgNet/SVGGraphics.cs
+++ b/SvgNet/SVGGraphics.cs
@@ -1992,15 +1992,13 @@ namespace SvgNet.SvgGdi
         /// </remarks>
         public void DrawPath(Pen pen, GraphicsPath path)
         {
-            foreach (SvgPath data in HandleGraphicsPath(path))
-            {
-                SvgPathElement pathElement = new SvgPathElement();
-                pathElement.Style = new SvgStyle(pen);
-                pathElement.D = data;
-                if (!_transforms.Result.IsIdentity)
-                    pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
-                _cur.AddChild(pathElement);
-            }
+            SvgPathElement pathElement = new SvgPathElement();
+            SvgPath data = HandleGraphicsPath(path);
+            pathElement.Style = new SvgStyle(pen);
+            pathElement.D = data;
+            if (!_transforms.Result.IsIdentity)
+                pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
+            _cur.AddChild(pathElement);
         }
 
         /// <summary>
@@ -2287,15 +2285,13 @@ namespace SvgNet.SvgGdi
         /// </summary>
         public void FillPath(Brush brush, GraphicsPath path)
         {
-            foreach (var svgPath in HandleGraphicsPath(path))
-            {
-                var pathElement = new SvgPathElement();
-                pathElement.Style = HandleBrush(brush);
-                pathElement.D = svgPath;
-                if (!_transforms.Result.IsIdentity)
-                    pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
-                _cur.AddChild(pathElement);
-            }
+            SvgPathElement pathElement = new SvgPathElement();
+            SvgPath svgPath = HandleGraphicsPath(path);
+            pathElement.Style = HandleBrush(brush);
+            pathElement.D = svgPath;
+            if (!_transforms.Result.IsIdentity)
+                pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
+            _cur.AddChild(pathElement);
         }
 
         /// <summary>
@@ -3557,7 +3553,7 @@ namespace SvgNet.SvgGdi
             _cur.AddChild(bez);
         }
 
-        private IEnumerable<SvgPath> HandleGraphicsPath(GraphicsPath path)
+        private SvgPath HandleGraphicsPath(GraphicsPath path)
         {
             StringBuilder pathBuilder = new StringBuilder();
             using (GraphicsPathIterator subpaths = new GraphicsPathIterator(path))
@@ -3589,6 +3585,7 @@ namespace SvgNet.SvgGdi
                         {
                             case PathPointType.Start:
                                 //Move to start point
+                                if (pathBuilder.Length > 0) pathBuilder.Append(" ");
                                 pathBuilder.AppendFormat(CultureInfo.InvariantCulture, "M {0},{1}", point.X, point.Y);
                                 break;
                             case PathPointType.Line:
@@ -3613,10 +3610,9 @@ namespace SvgNet.SvgGdi
                         // Close path
                         pathBuilder.Append(" Z");
                     }
-
-                    yield return new SvgPath(pathBuilder.ToString());
-                    pathBuilder.Clear();
                 }
+
+                return new SvgPath(pathBuilder.ToString());
             }
         }
 

--- a/SvgNet/SVGGraphics.cs
+++ b/SvgNet/SVGGraphics.cs
@@ -3546,6 +3546,14 @@ namespace SvgNet.SvgGdi
 
             bez.Style = HandleBrush(brush);
             bez.Transform = new SvgTransformList(_transforms.Result.Clone());
+            if (fillmode == FillMode.Alternate)
+            {
+                bez.Style.Set("fill-rule", "evenodd");
+            }
+            else
+            {
+                bez.Style.Set("fill-rule", "nonzero");
+            }
             _cur.AddChild(bez);
         }
 


### PR DESCRIPTION
This pull request fixes issue #22. The solution is merging all subpaths of a `GraphicsPath` into a single `SvgPath` specification, and then make sure that the fill-rule attribute is set according to the `FillMode` of the graphics path.

I couldn't build the current .NET Core solution even on VS 2017 (it was complaining of some strange project.json stuff), so I had to base the branch off the old 1.0.8 release. Nothing is really conflicting with the current source as I didn't change any project files, but I may need some pointers to rebase this to master.

Are there any plans to keep a branch for the old 1.0 version? I have a desktop application using .NET 4.0 and would like to incorporate these fixes without having to do some major updates on the app.