### PR TITLE
Fixed SVG export for filled interior of a closed path

### DIFF
--- a/SvgNet/Graphics/SVGGraphics.cs
+++ b/SvgNet/Graphics/SVGGraphics.cs
@@ -3329,6 +3329,13 @@ namespace SvgNet.SvgGdi
 
             bez.Style = HandleBrush(brush);
             bez.Transform = new SvgTransformList(_transforms.Result.Clone());
+            if (fillmode == FillMode.Alternate)
+            {
+                bez.Style.Set("fill-rule", "evenodd");
+            } else
+            {
+                bez.Style.Set("fill-rule", "nonzero");
+            }
             _cur.AddChild(bez);
         }
 

--- a/SvgNet/Graphics/SVGGraphics.cs
+++ b/SvgNet/Graphics/SVGGraphics.cs
@@ -2123,6 +2123,14 @@ namespace SvgNet.SvgGdi
                 Style = HandleBrush(brush),
                 D = data
             };
+            if (path.FillMode == FillMode.Alternate)
+            {
+                pathElement.Style.Set("fill-rule", "evenodd");
+            } else
+            {
+                pathElement.Style.Set("fill-rule", "nonzero");
+            }
+
             if (!_transforms.Result.IsIdentity)
                 pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
             _cur.AddChild(pathElement);

--- a/SvgNet/Graphics/SVGGraphics.cs
+++ b/SvgNet/Graphics/SVGGraphics.cs
@@ -1856,17 +1856,15 @@ namespace SvgNet.SvgGdi
         /// </remarks>
         public void DrawPath(Pen pen, GraphicsPath path)
         {
-            foreach (SvgPath data in HandleGraphicsPath(path))
+            SvgPath data = HandleGraphicsPath(path);
+            var pathElement = new SvgPathElement
             {
-                var pathElement = new SvgPathElement
-                {
-                    Style = new SvgStyle(pen),
-                    D = data
-                };
-                if (!_transforms.Result.IsIdentity)
-                    pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
-                _cur.AddChild(pathElement);
-            }
+                Style = new SvgStyle(pen),
+                D = data
+            };
+            if (!_transforms.Result.IsIdentity)
+                pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
+            _cur.AddChild(pathElement);
         }
 
         /// <summary>
@@ -2119,17 +2117,15 @@ namespace SvgNet.SvgGdi
         /// </summary>
         public void FillPath(Brush brush, GraphicsPath path)
         {
-            foreach (var svgPath in HandleGraphicsPath(path))
+            SvgPath data = HandleGraphicsPath(path);
+            var pathElement = new SvgPathElement
             {
-                var pathElement = new SvgPathElement
-                {
-                    Style = HandleBrush(brush),
-                    D = svgPath
-                };
-                if (!_transforms.Result.IsIdentity)
-                    pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
-                _cur.AddChild(pathElement);
-            }
+                Style = HandleBrush(brush),
+                D = data
+            };
+            if (!_transforms.Result.IsIdentity)
+                pathElement.Transform = new SvgTransformList(_transforms.Result.Clone());
+            _cur.AddChild(pathElement);
         }
 
         /// <summary>
@@ -3435,7 +3431,7 @@ namespace SvgNet.SvgGdi
             return new SvgStyle(new SolidBrush(Color.Salmon));
         }
 
-        private IEnumerable<SvgPath> HandleGraphicsPath(GraphicsPath path)
+        private SvgPath HandleGraphicsPath(GraphicsPath path)
         {
             var pathBuilder = new StringBuilder();
             using (var subpaths = new GraphicsPathIterator(path))
@@ -3466,6 +3462,7 @@ namespace SvgNet.SvgGdi
                         {
                             case PathPointType.Start:
                                 //Move to start point
+                                if (pathBuilder.Length > 0) pathBuilder.Append(" ");
                                 pathBuilder.AppendFormat(CultureInfo.InvariantCulture, "M {0},{1}", point.X, point.Y);
                                 break;
 
@@ -3493,10 +3490,9 @@ namespace SvgNet.SvgGdi
                         // Close path
                         pathBuilder.Append(" Z");
                     }
-
-                    yield return new SvgPath(pathBuilder.ToString());
-                    pathBuilder.Clear();
                 }
+
+                return new SvgPath(pathBuilder.ToString());
             }
         }
 

--- a/SvgNet/SvgNet.csproj
+++ b/SvgNet/SvgNet.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>SVG</AssemblyName>
     <PackageId>SvgNet</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>    
-    <Version>2.0.0</Version>    
+    <Version>2.0.1</Version>    
     <RootNamespace>SVG</RootNamespace>
     <DocumentationFile>svgnetdoc.xml</DocumentationFile>
     <NoWarn>CS1591</NoWarn>    
@@ -24,7 +24,10 @@
     <Product>SvgNet</Product>
     <ProductVersion>8.0.30319</ProductVersion>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>## 2.0.0 - Support for .NET Standard 2.0</PackageReleaseNotes>    
+    <PackageReleaseNotes>## 2.0.1 - Support for .NET Standard 2.0
+Merge PR #24 
+- Fix for Issue #22  Paths with overlaps doesn't fill correctly
+- Bezier paths didn't get filled</PackageReleaseNotes>    
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">    

--- a/TestShared/TestShared.cs
+++ b/TestShared/TestShared.cs
@@ -373,6 +373,10 @@ namespace SvgNet
             myPath.AddBeziers(pathPoints1);
             myPath.AddLines(pathPoints2);
 
+            // Add path closed interior test
+            myPath.AddEllipse(190, 15, 50, 50);
+            myPath.AddEllipse(225, 30, 30, 30);
+
             ig.FillPath(new SolidBrush(Color.Aqua), myPath);
             ig.DrawPath(new Pen(Color.Black, 5f), myPath);
         }


### PR DESCRIPTION
This pull request fixes issue #22. The solution is merging all subpaths of a `GraphicsPath` into a single `SvgPath` specification, and then make sure that the fill-rule attribute is set according to the `FillMode` of the graphics path.

This pull request is based off the updated master, and therefore supersedes pull-request #23. Turns out it was easier to just create a new PR on top of master, than rebasing the previous branch because of all the folder restructuring for 2.0.