### PR TITLE
Fixed the name of the image element

### DIFF
--- a/SvgNet/Elements/SvgSymbolElement.cs
+++ b/SvgNet/Elements/SvgSymbolElement.cs
@@ -42,7 +42,7 @@ namespace SvgNet.SvgElements {
             set => _atts["xlink:href"] = value;
         }
 
-        public override string Name => "use";
+        public override string Name => "image";
 
         public string PreserveAspectRatio {
             get => (string)_atts["preserveAspectRatio"];


### PR DESCRIPTION
The name of SvgImageElement is incorrect, so this is fixed.