### PR TITLE
Add net5.0-windows target

### DIFF
--- a/SvgNet/SvgNet.csproj
+++ b/SvgNet/SvgNet.csproj
@@ -43,7 +43,7 @@
   </Target>
   
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" Condition="'$(TargetFramework)' != 'net461'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SvgNet/SvgNet.csproj
+++ b/SvgNet/SvgNet.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0;net5.0-windows</TargetFrameworks>
+    <UseWindowsForms Condition="'$(TargetFramework)' == 'net5.0-windows'">true</UseWindowsForms>
     <LangVersion>9.0</LangVersion>
     <AssemblyName>SVG</AssemblyName>
     <PackageId>SvgNet</PackageId>
@@ -43,7 +44,7 @@
   </Target>
   
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" Condition="'$(TargetFramework)' != 'net461'" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" Condition="'$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net5.0-windows'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a new `TargetFramework` for `net5.0-windows`. When declaring this target, `System.Drawing.Common` is not necessary as a direct dependency, as it is expected to be included as part of the shared .NET 5.0 runtime on Windows platforms.

Edit: It also removes `System.Drawing.Common` from the legacy `net461` target, as it is also not necessary in that case.

Fixes #40