### PR TITLE
Remove dependency from System.ValueTuple

### DIFF
--- a/SvgNet/ImplementedGraphics/SVGGraphics.BitmapDrawer.cs
+++ b/SvgNet/ImplementedGraphics/SVGGraphics.BitmapDrawer.cs
@@ -12,11 +12,12 @@ namespace SvgNet;
 
 public sealed partial class SvgGraphics {
     private class BitmapDrawer {
-        public BitmapDrawer(SvgGroupElement g, float x, float y, (float X, float Y) scaling) {
+        public BitmapDrawer(SvgGroupElement g, float x, float y, float scaleX, float scaleY) {
             _groupElement = g;
             _x = x;
             _y = y;
-            (_scaleX, _scaleY) = scaling;
+            _scaleX = scaleX;
+            _scaleY = scaleY;
         }
 
         private readonly SvgGroupElement _groupElement;

--- a/SvgNet/ImplementedGraphics/SVGGraphics.cs
+++ b/SvgNet/ImplementedGraphics/SVGGraphics.cs
@@ -1753,7 +1753,11 @@ public sealed partial class SvgGraphics : IGraphics {
 
         sweepAngle += startAngle;
 
-        if (sweepAngle > startAngle) (sweepAngle, startAngle) = (startAngle, sweepAngle);
+        if (sweepAngle > startAngle) {
+            var temp = startAngle;
+            startAngle = sweepAngle;
+            sweepAngle = temp;
+        }
 
         if (sweepAngle - startAngle > Math.PI || startAngle - sweepAngle > Math.PI) longArc = 1;
 
@@ -1853,7 +1857,8 @@ public sealed partial class SvgGraphics : IGraphics {
             new SvgGroupElement("bitmap_at_" + x.ToString("F", CultureInfo.InvariantCulture) + "_" + y.ToString("F", CultureInfo.InvariantCulture)),
             x,
             y,
-            scale ? (w / b.Width, h / b.Height) : (1, 1))
+            scaleX: scale ? w / b.Width : 1,
+            scaleY: scale ? h / b.Height : 1)
             .DrawBitmapData(b);
         if (!_transforms.Result.IsIdentity)
             groupElement.Transform = _transforms.Result.Clone();

--- a/SvgNet/SvgNet.csproj
+++ b/SvgNet/SvgNet.csproj
@@ -67,7 +67,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.Drawing.Common" Version="6.0.0" Condition="'$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net5.0-windows' And '$(TargetFramework)' != 'net6.0-windows'" />
-		<PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)' == 'net461'" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR removes the need to depend on System.ValueTuple. It turns out that this feature was really only used in two places just as a shorthand notation. In this case, it seemed simpler to just avoid these very tiny cases and in return be able to target seamlessly a much broader range of platforms.

Fixes #58 