### PR TITLE
Avoid declaring extensions in the system namespace

### DIFF
--- a/SvgNet/Extensions/FloatExtensions.cs
+++ b/SvgNet/Extensions/FloatExtensions.cs
@@ -6,7 +6,7 @@
     Original source code licensed with BSD-2-Clause spirit, treat it thus, see accompanied LICENSE for more
 */
 
-namespace System;
+namespace SvgNet;
 
 public static class FloatExtensions {
     public static string ToInvariantString(this float value) =>

--- a/SvgNet/Extensions/MatrixExtensions.cs
+++ b/SvgNet/Extensions/MatrixExtensions.cs
@@ -6,7 +6,7 @@
     Original source code licensed with BSD-2-Clause spirit, treat it thus, see accompanied LICENSE for more
 */
 
-namespace System.Drawing.Drawing2D;
+namespace SvgNet;
 
 public static class MatrixExtensions {
 

--- a/SvgNet/Extensions/ObjectExtensions.cs
+++ b/SvgNet/Extensions/ObjectExtensions.cs
@@ -6,7 +6,7 @@
     Original source code licensed with BSD-2-Clause spirit, treat it thus, see accompanied LICENSE for more
 */
 
-namespace System;
+namespace SvgNet;
 public static class ObjectExtensions {
     public static object CloneIfPossible(this object o) => (o as ICloneable)?.Clone() ?? o;
 }

--- a/SvgNet/Extensions/StringExtensions.cs
+++ b/SvgNet/Extensions/StringExtensions.cs
@@ -6,7 +6,7 @@
     Original source code licensed with BSD-2-Clause spirit, treat it thus, see accompanied LICENSE for more
 */
 
-namespace System;
+namespace SvgNet;
 public static class StringExtensions {
     public static int ParseHex(this string s, int startIndex, int length = 1)
 #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER


### PR DESCRIPTION
This PR moves all extension methods to the `SvgNet` namespace to avoid accidental name clashes with 3rd party extension methods on common objects when bringing SvgNet into an existing project.

**Note:** this is technically a breaking change, since these extension methods are public. In practice the impact should be minimal since most projects should be importing the `SvgNet` namespace anyway in most contexts where these will be used, but it would require recompiling.

Fixes #72 